### PR TITLE
posicaoCrop() com x, y, width e height

### DIFF
--- a/canvas.php
+++ b/canvas.php
@@ -9,7 +9,7 @@
 */
 
 class canvas {
-
+	
     /**
      * Variáveis para armazenamento de arquivos/imgs
      **/
@@ -284,12 +284,20 @@ class canvas {
 
      /**
       * Armazena posições x e y para crop
-      * @param Array valores x e y
+      * @param Int x - posicao x do crop
+			* @param Int y - posicao y do crop
+			* @param Int w - width  - larguraOrigem (by OctaAugusto)
+			* @param Int h - height - alturaOrigem (by OctaAugusto)
       * @return Object instância atual do objeto, para métodos encadeados
       **/
-     public function posicaoCrop( $x, $y )
+     public function posicaoCrop( $x, $y, $w=0, $h=0 )
      {
-          $this->posicao_crop = array( $x, $y, $this->largura, $this->altura );
+          // sem largura ou altura setada manualmente, pega original da imagem
+		  		if(!$w) $w = $this->largura;
+		  		if(!$h) $h = $this->altura;
+		  
+          $this->posicao_crop = array( $x, $y, $w, $h );
+
           return $this;
      } // fim posicao_crop
 
@@ -304,7 +312,7 @@ class canvas {
      {
 
           // seta variáveis passadas via parâmetro
-          $this->nova_largura          = $nova_largura;
+          $this->nova_largura         = $nova_largura;
           $this->nova_altura          = $nova_altura;
 
           // verifica se passou altura ou largura como porcentagem
@@ -502,8 +510,16 @@ class canvas {
       **/
      private function redimensionaCrop()
      {
-          // calcula posicionamento do crop
-          $this->calculaPosicaoCrop();
+          // calcula posicionamento do crop automaticamente
+          if(!is_array($this->posicao_crop))
+          {
+          	$auto=1; 
+          	$this->calculaPosicaoCrop(); 
+		  		}
+		  		// posicionamento do crop setado manualmente
+		  		else {
+		  			$auto = 0;
+		  		}
 
           // cria imagem de destino temporária
           $this->img_temp = imagecreatetruecolor( $this->nova_largura, $this->nova_altura );
@@ -571,7 +587,8 @@ class canvas {
 	  $this->posicao_crop[ 0 ] = $this->pos_x;
 	  $this->posicao_crop[ 1 ] = $this->pos_y;
 
-          imagecopyresampled( $this->img_temp, $this->img, -$this->posicao_crop[0], -$this->posicao_crop[1], 0, 0, $this->posicao_crop[2], $this->posicao_crop[3], $this->largura, $this->altura );
+          if($auto) 	imagecopyresampled( $this->img_temp, $this->img, -$this->posicao_crop[0], -$this->posicao_crop[1], 0, 0, $this->posicao_crop[2], $this->posicao_crop[3], $this->largura, $this->altura );
+		  		else 				imagecopyresampled( $this->img_temp, $this->img, 0, 0, $this->posicao_crop[0], $this->posicao_crop[1], $this->nova_largura, $this->nova_altura, $this->posicao_crop[2], $this->posicao_crop[3] );
 
           $this->img     = $this->img_temp;
      } // fim redimensionaCrop


### PR DESCRIPTION
Torna possível setar posX, posY, larguraOrigem e alturaOrigem para
leitura do crop.
Usado especialmente em aplicações como Jcrop.

Destaque para o método posicaoCrop(), usado antes do método
redimensiona().

Ex de uso, tendo uma imagem de origem com 500x500 pixels:
$img->
carrega('imagemOriginal.jpg')->
posicaoCrop(70, 60, 100, 200)->
redimensiona(50, 100, 'crop')->
grava('imagemCropada.jpg');
