### PR TITLE
Erro falta de extensão em maquina linux.

### DIFF
--- a/canvas.php
+++ b/canvas.php
@@ -146,7 +146,7 @@ class canvas {
      {
           // imagem de origem
           $pathinfo            = pathinfo( $this->origem );
-          $this->extensao      = strtolower( $pathinfo['extension'] );
+          $this->extensao = array_key_exists('extension', $pathinfo) ? strtolower($pathinfo['extension']) : strtolower(str_replace('image/', '', $obj['mime']));
           $this->arquivo       = $pathinfo['basename'];
           $this->diretorio     = $pathinfo['dirname'];
      } // fim dadosArquivo


### PR DESCRIPTION
Como no linux o arquivo temporário gerado em um upload não existe extensão no nome do arquivo coloquei uma validação simples para quando não existir pegar pelo mimetype da imagem.

O erro que aparecia:

Undefined index: extension in /var/www/captura.me/vendor/Library/Canvas/Canvas.php on line 149

Solução proposta foi essa:

$this->extensao = array_key_exists('extension', $pathinfo) ? strtolower($pathinfo['extension']) : strtolower(str_replace('image/', '', $obj['mime']));

Espero ter ajudado!
