### PR TITLE
Update canvas.php

### DIFF
--- a/canvas.php
+++ b/canvas.php
@@ -158,7 +158,8 @@ class canvas
     {
         // imagem de origem
         $pathinfo        = pathinfo($this->origem);
-        $this->extensao  = array_key_exists('extension', $pathinfo) ? strtolower($pathinfo['extension']) : strtolower(str_replace('image/', '', $obj['mime']));
+        $obj = getimagesize($this->origem);
+        $this->extensao = strtolower(str_replace('image/', '', $obj['mime']));
         $this->arquivo   = $pathinfo['basename'];
         $this->diretorio = $pathinfo['dirname'];
     } // fim dadosArquivo
@@ -205,8 +206,8 @@ class canvas
     public function carregaUrl($url)
     {
         $this->origem   = $url;
-        $pathinfo       = pathinfo($this->origem);
-        $this->extensao = strtolower($pathinfo['extension']);
+        $obj = getimagesize($this->origem);
+        $this->extensao = strtolower(str_replace('image/', '', $obj['mime']));
         switch ($this->extensao) {
             case 'jpg':
             case 'jpeg':


### PR DESCRIPTION
Pegar a extensão no MIME com getimagesize é mais seguro que venha a extensão certa, estava tendo problemas em pegar uma imagem em png em link externo. O arquivo era .png mas no MIME vinha jpeg então não abria a imagem.
